### PR TITLE
[codex] Patch frontend transitive vulnerabilities

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,6 @@
       "js-yaml": ">=4.1.1",
       "on-headers": ">=1.1.0",
       "@eslint/plugin-kit": ">=0.3.4",
-      "brace-expansion": ">=2.0.2",
       "minimatch@3": "^3.1.3",
       "minimatch@9": ">=9.0.6",
       "ajv@6": "^6.14.0",
@@ -43,7 +42,10 @@
       "rollup": ">=4.59.0",
       "flatted": ">=3.4.2",
       "picomatch@2": "^2.3.2",
-      "picomatch@4": "^4.0.4"
+      "picomatch@4": "^4.0.4",
+      "fast-uri": ">=3.1.2",
+      "brace-expansion": ">=5.0.5",
+      "postcss": ">=8.5.10"
     }
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   js-yaml: '>=4.1.1'
   on-headers: '>=1.1.0'
   '@eslint/plugin-kit': '>=0.3.4'
-  brace-expansion: '>=2.0.2'
+  brace-expansion: '>=5.0.5'
   minimatch@3: ^3.1.3
   minimatch@9: '>=9.0.6'
   ajv@6: ^6.14.0
@@ -17,6 +17,8 @@ overrides:
   flatted: '>=3.4.2'
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
+  fast-uri: '>=3.1.2'
+  postcss: '>=8.5.10'
 
 importers:
 
@@ -663,17 +665,17 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  balanced-match@3.0.1:
-    resolution: {integrity: sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w==}
-    engines: {node: '>= 16'}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   boxen@7.0.0:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@4.0.1:
-    resolution: {integrity: sha512-YClrbvTCXGe70pU2JiEiPLYXO9gQkyxYeKpJIQHVS/gOs6EWMQP2RYBwjFLNT322Ji8TOC3IMPfsYCedNpzKfA==}
-    engines: {node: '>= 18'}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -871,8 +873,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1169,8 +1171,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1948,7 +1950,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1972,7 +1974,7 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  balanced-match@3.0.1: {}
+  balanced-match@4.0.4: {}
 
   boxen@7.0.0:
     dependencies:
@@ -1985,9 +1987,9 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@4.0.1:
+  brace-expansion@5.0.6:
     dependencies:
-      balanced-match: 3.0.1
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -2217,7 +2219,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.19.1:
     dependencies:
@@ -2375,11 +2377,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 4.0.1
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 4.0.1
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 
@@ -2440,7 +2442,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.8:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2670,7 +2672,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.14
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
## What changed
This PR patches the remaining frontend transitive dependency vulnerabilities by tightening `pnpm.overrides` and regenerating the frontend lockfile.

It forces patched versions for:
- `fast-uri >= 3.1.2`
- `brace-expansion >= 5.0.5`
- `postcss >= 8.5.10`

## Why
GitHub Dependabot was still reporting unresolved vulnerabilities coming from the frontend dependency tree:
- `fast-uri` path traversal and host confusion issues via `serve`
- `brace-expansion` zero-step sequence DoS
- `postcss` stringification XSS issue

The direct frontend dependencies did not need to change; the issue was in transitive resolution.

## Impact
- Removes vulnerable transitive versions from the frontend lockfile
- Keeps the current direct dependency set intact
- Makes future installs deterministic through explicit overrides

## Root cause
The vulnerable packages were being pulled transitively by the existing frontend dependency graph, and the current lockfile still resolved to the affected versions.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm run build`