### PR TITLE
Harden authentication and deployment security

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -16,8 +16,16 @@ SPOTIFY_CLIENT_SECRET=your-spotify-client-secret
 # Debug mode (set to True only for development)
 DEBUG=False
 
-# Allowed hosts (comma-separated, * allows all)
-ALLOWED_HOSTS=*
+# Public/backend hosts accepted by Django (comma-separated; do not use * in production)
+ALLOWED_HOSTS=localhost,127.0.0.1,backend,trackwatch.emlopezr.com
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,https://trackwatch.emlopezr.com
+CSRF_TRUSTED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,https://trackwatch.emlopezr.com
+
+# Enable HSTS only after HTTPS is working reliably for the configured domain.
+SECURE_SSL_REDIRECT=False
+SECURE_HSTS_SECONDS=0
+SECURE_HSTS_INCLUDE_SUBDOMAINS=False
+SECURE_HSTS_PRELOAD=False
 
 # Frontend port (default: 80)
 PORT=80

--- a/Dockerfile.aio
+++ b/Dockerfile.aio
@@ -1,22 +1,22 @@
 # ============================================================
 # Stage 1: Build the React frontend
 # ============================================================
-FROM node:20-alpine AS frontend-builder
+FROM node:22-alpine AS frontend-builder
 
 WORKDIR /app
 
 # Copy package files first for better caching
-COPY frontend/package.json frontend/pnpm-lock.yaml* frontend/package-lock.json* ./
+COPY frontend/package.json frontend/pnpm-lock.yaml* frontend/pnpm-workspace.yaml frontend/package-lock.json* ./
 
 # Install pnpm and dependencies
-RUN corepack enable && corepack prepare pnpm@10.6.3 --activate
-RUN pnpm install --frozen-lockfile || npm ci
+RUN corepack enable && corepack prepare pnpm@11.11.0 --activate
+RUN pnpm install --frozen-lockfile
 
 # Copy frontend source code
 COPY frontend/ .
 
 # Build the application
-RUN pnpm run build || npm run build
+RUN pnpm run build
 
 # ============================================================
 # Stage 2: Production runtime (Python + Nginx + supervisord)
@@ -43,6 +43,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     nginx \
     postgresql \
     postgresql-client \
+    util-linux \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better caching
@@ -66,7 +67,11 @@ COPY supervisord.conf /etc/supervisord.conf
 
 # Copy and set permissions for entrypoint script
 COPY entrypoint-aio.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN groupadd --system --gid 1001 trackwatch \
+    && useradd --system --uid 1001 --gid trackwatch --home-dir /app trackwatch \
+    && mkdir -p /app/staticfiles \
+    && chown -R trackwatch:trackwatch /app \
+    && chmod +x /entrypoint.sh
 
 # Prepare PostgreSQL data and run directories
 RUN mkdir -p /var/lib/postgresql/data /run/postgresql \

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,14 @@
 SECRET_KEY=?????
 ADMIN_KEY=?????
-ALLOWED_HOSTS=*
+ALLOWED_HOSTS=localhost,127.0.0.1,trackwatch.emlopezr.com
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,https://trackwatch.emlopezr.com
+CSRF_TRUSTED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,https://trackwatch.emlopezr.com
 DEBUG=True
+
+SECURE_SSL_REDIRECT=False
+SECURE_HSTS_SECONDS=0
+SECURE_HSTS_INCLUDE_SUBDOMAINS=False
+SECURE_HSTS_PRELOAD=False
 
 # Use either DATABASE_URL or the individual DATABASE_* variables below.
 # DATABASE_URL=postgres://user:password@host:5432/dbname

--- a/backend/app/admin.py
+++ b/backend/app/admin.py
@@ -6,6 +6,13 @@ class UserAdmin(admin.ModelAdmin):
   list_display = ['id', 'name', 'email', 'playlist_id']
   search_fields = ['name', 'email', 'id']
   readonly_fields = ['id']
+  exclude = [
+    'password',
+    'current_access_token',
+    'current_refresh_token',
+    'last_access_token',
+    'last_refresh_token',
+  ]
 
 @admin.register(UserRecentlyAddedTrack)
 class UserRecentlyAddedTrackAdmin(admin.ModelAdmin):

--- a/backend/app/authentication.py
+++ b/backend/app/authentication.py
@@ -1,0 +1,24 @@
+from rest_framework import exceptions
+from rest_framework.authentication import BaseAuthentication, CSRFCheck
+
+from app.services.session_service import get_session_user
+
+
+def _dummy_get_response(request):
+  return None
+
+
+class TrackWatchSessionAuthentication(BaseAuthentication):
+  """Authenticate TrackWatch's Spotify-backed session and enforce CSRF."""
+
+  def authenticate(self, request):
+    user = get_session_user(request)
+    self.enforce_csrf(request)
+    return user, None
+
+  def enforce_csrf(self, request):
+    check = CSRFCheck(_dummy_get_response)
+    check.process_request(request)
+    reason = check.process_view(request, None, (), {})
+    if reason:
+      raise exceptions.PermissionDenied(f"CSRF Failed: {reason}")

--- a/backend/app/exceptions/exceptions.py
+++ b/backend/app/exceptions/exceptions.py
@@ -27,6 +27,7 @@ class ErrorCode:
   SPOTIFY_FORBIDDEN_REQUEST = ("SPOTIFY_FORBIDDEN_REQUEST", "Spotify API request forbidden request")
   SPOTIFY_USER_NOT_FOUND = ("SPOTIFY_USER_NOT_FOUND", "Spotify user not found")
   INVALID_ADMIN_CREDENTIALS = ("INVALID_ADMIN_CREDENTIALS", "Invalid admin credentials")
+  PLAYLIST_ACCESS_DENIED = ("PLAYLIST_ACCESS_DENIED", "Playlist access denied")
 
 def exception_response_dto(status, code, message, details=""):
   return {

--- a/backend/app/services/ghost_tracks_service.py
+++ b/backend/app/services/ghost_tracks_service.py
@@ -1,10 +1,13 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
+import logging
 import time
 from app.clients.spotify.spotify_playlist_api_client import (
     get_user_playlists,
     get_playlist_tracks_with_market,
     remove_tracks_from_playlist
 )
+
+logger = logging.getLogger(__name__)
 
 
 def get_owned_playlists(token, user_id):
@@ -78,14 +81,15 @@ def scan_playlist_for_ghost_tracks(token, playlist_id, playlist_name, market):
             "scannedTracks": scanned,
             "error": None
         }
-    except Exception as e:
+    except Exception:
+        logger.warning("Unable to scan Spotify playlist %s", playlist_id)
         return {
             "playlistId": playlist_id,
             "playlistName": playlist_name,
             "ghostTracks": [],
             "totalTracks": 0,
             "scannedTracks": 0,
-            "error": str(e)
+            "error": "Unable to scan playlist"
         }
 
 

--- a/backend/app/services/session_service.py
+++ b/backend/app/services/session_service.py
@@ -8,11 +8,7 @@ from app.services.user_service import get_valid_access_token
 
 
 def get_public_origin(request):
-  forwarded_proto = request.headers.get("X-Forwarded-Proto")
-  forwarded_host = request.headers.get("X-Forwarded-Host")
-  host = forwarded_host or request.get_host()
-  proto = forwarded_proto or request.scheme or "http"
-  return f"{proto}://{host}"
+  return settings.FRONTEND_BASE_URL
 
 
 def get_spotify_redirect_uri(request):
@@ -20,10 +16,7 @@ def get_spotify_redirect_uri(request):
 
 
 def get_allowed_redirect_origins(request):
-  return {
-    *getattr(settings, "CORS_ALLOWED_ORIGINS", []),
-    get_public_origin(request),
-  }
+  return set(getattr(settings, "CORS_ALLOWED_ORIGINS", []))
 
 
 def validate_spotify_redirect_uri(request, redirect_uri):
@@ -33,6 +26,7 @@ def validate_spotify_redirect_uri(request, redirect_uri):
   if (
     parsed.scheme not in {"http", "https"}
     or not parsed.netloc
+    or (parsed.scheme == "http" and parsed.hostname not in {"localhost", "127.0.0.1"})
     or parsed.path != "/callback"
     or parsed.params
     or parsed.query

--- a/backend/app/tests/test_actions_view.py
+++ b/backend/app/tests/test_actions_view.py
@@ -35,3 +35,27 @@ class UpdateNewReleasesViewTests(SimpleTestCase):
     self.assertEqual(response.status_code, 403)
     self.assertEqual(payload["code"], "INVALID_ADMIN_CREDENTIALS")
     mock_thread.assert_not_called()
+
+  @patch("app.views.actions_view.threading.Thread")
+  @patch("app.views.actions_view.config", return_value=None)
+  def test_update_new_releases_does_not_fall_back_to_django_secret_key(self, mock_config, mock_thread):
+    response = self.client.post(
+      "/actions/releases",
+      HTTP_X_ADMIN_KEY="django-secret-key",
+    )
+
+    self.assertEqual(response.status_code, 403)
+    mock_thread.assert_not_called()
+
+  @patch("app.views.actions_view.threading.Thread")
+  @patch("app.views.actions_view.config", return_value="admin-secret")
+  def test_update_new_releases_rejects_out_of_range_days_limit(self, mock_config, mock_thread):
+    response = self.client.post(
+      "/actions/releases?daysLimit=1000000",
+      HTTP_X_ADMIN_KEY="admin-secret",
+    )
+
+    payload = json.loads(response.content)
+    self.assertEqual(response.status_code, 400)
+    self.assertEqual(payload["code"], "INVALID_REQUEST_BODY")
+    mock_thread.assert_not_called()

--- a/backend/app/tests/test_admin.py
+++ b/backend/app/tests/test_admin.py
@@ -1,0 +1,20 @@
+from django.contrib import admin
+from django.test import SimpleTestCase
+
+from app.admin import UserAdmin
+from app.models import User
+
+
+class UserAdminSecurityTests(SimpleTestCase):
+  def test_sensitive_credentials_are_excluded(self):
+    user_admin = UserAdmin(User, admin.site)
+
+    excluded = set(user_admin.get_exclude(request=None))
+
+    self.assertTrue({
+      "password",
+      "current_access_token",
+      "current_refresh_token",
+      "last_access_token",
+      "last_refresh_token",
+    }.issubset(excluded))

--- a/backend/app/tests/test_auth_view.py
+++ b/backend/app/tests/test_auth_view.py
@@ -1,0 +1,31 @@
+import json
+from unittest.mock import Mock, patch
+
+from django.test import RequestFactory, SimpleTestCase
+
+from app.constants import Spotify
+from app.views.auth_view import spotify_exchange
+
+
+class SpotifyExchangeSecurityTests(SimpleTestCase):
+  def setUp(self):
+    self.factory = RequestFactory()
+
+  @patch("app.views.auth_view.spotify_auth_raw_request")
+  def test_oauth_state_is_consumed_before_upstream_exchange(self, spotify_request):
+    spotify_request.return_value = Mock(status_code=400)
+    spotify_request.return_value.json.return_value = {"error": "invalid_grant"}
+    request = self.factory.post(
+      "/auth/spotify/exchange",
+      data=json.dumps({"code": "spotify-code", "state": "oauth-state"}),
+      content_type="application/json",
+    )
+    request.session = {
+      Spotify.OAUTH_STATE_KEY: "oauth-state",
+      Spotify.OAUTH_REDIRECT_URI_KEY: "https://trackwatch.emlopezr.com/callback",
+    }
+
+    response = spotify_exchange(request)
+
+    self.assertEqual(response.status_code, 400)
+    self.assertNotIn(Spotify.OAUTH_STATE_KEY, request.session)

--- a/backend/app/tests/test_ghost_tracks_service.py
+++ b/backend/app/tests/test_ghost_tracks_service.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from app.services.ghost_tracks_service import scan_playlist_for_ghost_tracks
+
+
+class GhostTracksServiceSecurityTests(SimpleTestCase):
+  @patch("app.services.ghost_tracks_service.get_playlist_tracks_with_market")
+  def test_scan_error_does_not_expose_upstream_details(self, get_tracks):
+    get_tracks.side_effect = RuntimeError("secret upstream response")
+
+    result = scan_playlist_for_ghost_tracks("token", "A" * 22, "Playlist", "CO")
+
+    self.assertEqual(result["error"], "Unable to scan playlist")
+    self.assertNotIn("secret", result["error"])

--- a/backend/app/tests/test_ghost_tracks_view.py
+++ b/backend/app/tests/test_ghost_tracks_view.py
@@ -18,6 +18,7 @@ class FakeSession(dict):
 
 class FakeUser:
   id = "spotify-user-id"
+  is_authenticated = True
 
 
 class GhostTracksViewReauthorizationTests(SimpleTestCase):
@@ -25,7 +26,7 @@ class GhostTracksViewReauthorizationTests(SimpleTestCase):
     self.client = Client()
 
   @override_settings(DEBUG=False, SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies")
-  @patch("app.views.ghost_tracks_view.get_session_user", return_value=FakeUser())
+  @patch("app.authentication.get_session_user", return_value=FakeUser())
   @patch("app.views.ghost_tracks_view.with_user_access_token")
   def test_get_playlists_preserves_spotify_reauthorization_required(self, with_token, get_user):
     with_token.side_effect = SpotifyReauthorizationRequiredException(ErrorCode.SPOTIFY_REAUTH_REQUIRED)
@@ -35,3 +36,66 @@ class GhostTracksViewReauthorizationTests(SimpleTestCase):
     payload = json.loads(response.content)
     self.assertEqual(response.status_code, 401)
     self.assertEqual(payload["code"], "SPOTIFY_REAUTH_REQUIRED")
+
+
+class GhostTracksViewSecurityTests(SimpleTestCase):
+  PLAYLIST_ID = "A" * 22
+  OTHER_PLAYLIST_ID = "B" * 22
+  TRACK_URI = f"spotify:track:{'C' * 22}"
+
+  def setUp(self):
+    self.client = Client(enforce_csrf_checks=True)
+
+  @patch("app.authentication.get_session_user", return_value=FakeUser())
+  def test_scan_requires_csrf_token(self, get_user):
+    response = self.client.post(
+      "/ghost-tracks/scan",
+      data=json.dumps({"playlistIds": [self.PLAYLIST_ID]}),
+      content_type="application/json",
+    )
+
+    self.assertEqual(response.status_code, 403)
+
+  @patch("app.authentication.get_session_user", return_value=FakeUser())
+  def test_remove_requires_csrf_token(self, get_user):
+    response = self.client.post(
+      "/ghost-tracks/remove",
+      data=json.dumps({
+        "removals": [{"playlistId": self.PLAYLIST_ID, "trackUris": [self.TRACK_URI]}],
+      }),
+      content_type="application/json",
+    )
+
+    self.assertEqual(response.status_code, 403)
+
+  @patch("app.views.ghost_tracks_view.get_owned_playlists")
+  @patch("app.authentication.get_session_user", return_value=FakeUser())
+  @patch("app.views.ghost_tracks_view.with_user_access_token")
+  def test_scan_rejects_playlist_not_owned_by_session_user(self, with_token, get_user, get_owned):
+    with_token.side_effect = lambda user, callback: callback("token")
+    get_owned.return_value = [{"id": self.PLAYLIST_ID, "name": "Owned"}]
+    client = Client(enforce_csrf_checks=False)
+
+    response = client.post(
+      "/ghost-tracks/scan",
+      data=json.dumps({"playlistIds": [self.OTHER_PLAYLIST_ID]}),
+      content_type="application/json",
+    )
+
+    payload = json.loads(response.content)
+    self.assertEqual(response.status_code, 403)
+    self.assertEqual(payload["code"], "PLAYLIST_ACCESS_DENIED")
+
+  @patch("app.authentication.get_session_user", return_value=FakeUser())
+  def test_scan_rejects_malformed_playlist_id(self, get_user):
+    client = Client(enforce_csrf_checks=False)
+
+    response = client.post(
+      "/ghost-tracks/scan",
+      data=json.dumps({"playlistIds": ["../not-a-spotify-id"]}),
+      content_type="application/json",
+    )
+
+    payload = json.loads(response.content)
+    self.assertEqual(response.status_code, 400)
+    self.assertEqual(payload["code"], "INVALID_REQUEST_BODY")

--- a/backend/app/tests/test_session_service.py
+++ b/backend/app/tests/test_session_service.py
@@ -43,3 +43,28 @@ class SpotifyRedirectUriTests(SimpleTestCase):
         request,
         "https://trackwatch.emlopezr.com/callback?next=https://evil.example",
       )
+
+  @override_settings(CORS_ALLOWED_ORIGINS=["http://trackwatch.example"])
+  def test_rejects_insecure_non_local_callback(self):
+    request = self.factory.get("/auth/spotify/login")
+
+    with self.assertRaises(BadRequestException):
+      validate_spotify_redirect_uri(request, "http://trackwatch.example/callback")
+
+  @override_settings(
+    CORS_ALLOWED_ORIGINS=["https://trackwatch.emlopezr.com"],
+    FRONTEND_BASE_URL="https://trackwatch.emlopezr.com",
+  )
+  def test_does_not_trust_forwarded_host_for_default_redirect(self):
+    request = self.factory.get(
+      "/auth/spotify/login",
+      HTTP_X_FORWARDED_PROTO="https",
+      HTTP_X_FORWARDED_HOST="evil.example",
+    )
+
+    from app.services.session_service import get_spotify_redirect_uri
+
+    self.assertEqual(
+      get_spotify_redirect_uri(request),
+      "https://trackwatch.emlopezr.com/callback",
+    )

--- a/backend/app/views/actions_view.py
+++ b/backend/app/views/actions_view.py
@@ -5,12 +5,29 @@ from app.constants import Headers, System
 from app.services import generate_artist_playlist as generate_artist_playlist_use_case, update_new_releases_for_all_users
 from decouple import config
 from app.exceptions import ForbiddenException, ErrorCode
+from app.exceptions import BadRequestException
+import secrets
 import threading
 from app.services.session_service import get_session_user, with_user_access_token
 
 
 def get_admin_key():
-  return config("ADMIN_KEY", default=None) or config("SECRET_KEY")
+  return config("ADMIN_KEY", default=None)
+
+
+def parse_days_limit(raw_days_limit):
+  if raw_days_limit is None:
+    return System.FILTER_DAYS_LIMIT
+
+  try:
+    days_limit = int(raw_days_limit)
+  except (TypeError, ValueError):
+    raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="daysLimit must be an integer")
+
+  if not 1 <= days_limit <= 90:
+    raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="daysLimit must be between 1 and 90")
+
+  return days_limit
 
 
 @require_POST
@@ -35,12 +52,12 @@ def generate_artist_playlist(request):
 @require_POST
 def update_new_releases(request):
   admin_key = request.headers.get(Headers.ADMIN_KEY)
+  expected_admin_key = get_admin_key()
 
-  if admin_key != get_admin_key():
+  if not admin_key or not expected_admin_key or not secrets.compare_digest(admin_key, expected_admin_key):
     raise ForbiddenException(ErrorCode.INVALID_ADMIN_CREDENTIALS)
 
-  days_limit = request.GET.get('daysLimit')
-  days_limit = int(days_limit) if days_limit else System.FILTER_DAYS_LIMIT
+  days_limit = parse_days_limit(request.GET.get('daysLimit'))
 
   # Run in background thread to avoid Gunicorn worker timeout
   thread = threading.Thread(

--- a/backend/app/views/auth_view.py
+++ b/backend/app/views/auth_view.py
@@ -53,8 +53,14 @@ def spotify_exchange(request):
   if not code or not state:
     raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY)
 
-  if not session_state or state != session_state:
+  if (
+    not isinstance(state, str)
+    or not isinstance(session_state, str)
+    or not secrets.compare_digest(state, session_state)
+  ):
     raise UnauthorizedException(ErrorCode.USER_INVALID_CREDENTIALS)
+
+  request.session.pop(Spotify.OAUTH_STATE_KEY, None)
 
   response = spotify_auth_raw_request(
     method="POST",
@@ -78,7 +84,6 @@ def spotify_exchange(request):
 
   user, user_dict = authenticate_spotify_user(access_token, refresh_token)
   set_authenticated_session(request, user)
-  request.session.pop(Spotify.OAUTH_STATE_KEY, None)
   request.session.pop(Spotify.OAUTH_REDIRECT_URI_KEY, None)
   return JsonResponse(user_dict, status=200)
 

--- a/backend/app/views/ghost_tracks_view.py
+++ b/backend/app/views/ghost_tracks_view.py
@@ -1,163 +1,146 @@
 import re
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework import status
+from app.authentication import TrackWatchSessionAuthentication
 from app.services.ghost_tracks_service import (
     get_owned_playlists,
     scan_playlists_parallel,
     remove_tracks_from_playlists
 )
-from app.exceptions import SpotifyReauthorizationRequiredException
-from app.services.session_service import get_session_user, with_user_access_token
+from app.exceptions import BadRequestException, ErrorCode, ForbiddenException
+from app.services.session_service import with_user_access_token
 
 
 DEFAULT_COUNTRY_CODE = "CO"
+MAX_PLAYLISTS_PER_REQUEST = 50
+MAX_TRACKS_PER_PLAYLIST = 1000
+MAX_TRACKS_PER_REQUEST = 5000
+SPOTIFY_ID_PATTERN = re.compile(r"^[A-Za-z0-9]{22}$")
+SPOTIFY_TRACK_URI_PATTERN = re.compile(r"^spotify:track:[A-Za-z0-9]{22}$")
 
 
-def get_token_and_user(request):
-    try:
-        user = get_session_user(request)
-        return user, None
-    except Exception as e:
-        return None, Response(
-            {"error": f"Failed to authenticate user: {str(e)}"},
-            status=status.HTTP_401_UNAUTHORIZED
-        )
+def _validate_playlist_ids(playlist_ids):
+    if not isinstance(playlist_ids, list) or not playlist_ids:
+        raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="playlistIds must be a non-empty array")
+    if len(playlist_ids) > MAX_PLAYLISTS_PER_REQUEST:
+        raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="Too many playlists requested")
+    if any(not isinstance(playlist_id, str) or not SPOTIFY_ID_PATTERN.fullmatch(playlist_id) for playlist_id in playlist_ids):
+        raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="Invalid Spotify playlist ID")
+    if len(set(playlist_ids)) != len(playlist_ids):
+        raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="playlistIds must be unique")
+    return playlist_ids
+
+
+def _validate_removals(removals):
+    if not isinstance(removals, list) or not removals:
+        raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="removals must be a non-empty array")
+    if len(removals) > MAX_PLAYLISTS_PER_REQUEST:
+        raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="Too many playlists requested")
+
+    validated = []
+    total_tracks = 0
+    playlist_ids = []
+    for removal in removals:
+        if not isinstance(removal, dict):
+            raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="Each removal must be an object")
+
+        playlist_id = removal.get("playlistId")
+        track_uris = removal.get("trackUris")
+        if not isinstance(playlist_id, str) or not SPOTIFY_ID_PATTERN.fullmatch(playlist_id):
+            raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="Invalid Spotify playlist ID")
+        if not isinstance(track_uris, list) or not track_uris or len(track_uris) > MAX_TRACKS_PER_PLAYLIST:
+            raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="Invalid trackUris list")
+        if any(not isinstance(uri, str) or not SPOTIFY_TRACK_URI_PATTERN.fullmatch(uri) for uri in track_uris):
+            raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="Invalid Spotify track URI")
+        if len(set(track_uris)) != len(track_uris):
+            raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="trackUris must be unique")
+
+        playlist_ids.append(playlist_id)
+        total_tracks += len(track_uris)
+        validated.append({"playlistId": playlist_id, "trackUris": track_uris})
+
+    if len(set(playlist_ids)) != len(playlist_ids):
+        raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="Playlist removals must be unique")
+    if total_tracks > MAX_TRACKS_PER_REQUEST:
+        raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="Too many tracks requested")
+    return validated
+
+
+def _owned_playlist_map(user):
+    owned_playlists = with_user_access_token(
+        user,
+        lambda access_token: get_owned_playlists(access_token, user.id)
+    )
+    return {playlist["id"]: playlist["name"] for playlist in owned_playlists}
+
+
+def _require_owned_playlists(playlist_ids, playlist_map):
+    if any(playlist_id not in playlist_map for playlist_id in playlist_ids):
+        raise ForbiddenException(ErrorCode.PLAYLIST_ACCESS_DENIED)
 
 
 @api_view(['GET'])
-@authentication_classes([])
-@permission_classes([])
+@authentication_classes([TrackWatchSessionAuthentication])
+@permission_classes([IsAuthenticated])
 def get_playlists(request):
-    user, error_response = get_token_and_user(request)
-
-    if error_response:
-        return error_response
-
-    try:
-        playlists = with_user_access_token(
-            user,
-            lambda access_token: get_owned_playlists(access_token, user.id)
-        )
-        return Response({"playlists": playlists}, status=status.HTTP_200_OK)
-    except SpotifyReauthorizationRequiredException:
-        raise
-    except Exception as e:
-        return Response(
-            {"error": str(e)},
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR
-        )
+    user = request.user
+    playlists = with_user_access_token(
+        user,
+        lambda access_token: get_owned_playlists(access_token, user.id)
+    )
+    return Response({"playlists": playlists}, status=status.HTTP_200_OK)
 
 
 @api_view(['POST'])
-@authentication_classes([])
-@permission_classes([])
+@authentication_classes([TrackWatchSessionAuthentication])
+@permission_classes([IsAuthenticated])
 def scan_ghost_tracks(request):
-    user, error_response = get_token_and_user(request)
-    if error_response:
-        return error_response
+    user = request.user
 
-    # Parse request body
-    playlist_ids = request.data.get("playlistIds", [])
+    playlist_ids = _validate_playlist_ids(request.data.get("playlistIds"))
     country_code = request.data.get("countryCode", DEFAULT_COUNTRY_CODE)
 
-    # Validate playlist IDs
-    if not playlist_ids or not isinstance(playlist_ids, list):
-        return Response(
-            {"error": "playlistIds is required and must be a non-empty array"},
-            status=status.HTTP_400_BAD_REQUEST
-        )
+    if not isinstance(country_code, str) or not re.fullmatch(r'[A-Z]{2}', country_code):
+        raise BadRequestException(ErrorCode.INVALID_REQUEST_BODY, details="Invalid countryCode")
 
-    # T042: Validate country code format (ISO 3166-1 alpha-2)
-    if not re.match(r'^[A-Z]{2}$', country_code):
-        return Response(
-            {"error": "countryCode must be a valid ISO 3166-1 alpha-2 code (e.g., 'CO', 'US')"},
-            status=status.HTTP_400_BAD_REQUEST
-        )
+    playlist_map = _owned_playlist_map(user)
+    _require_owned_playlists(playlist_ids, playlist_map)
 
-    try:
-        # Get playlist names for the response
-        owned_playlists = with_user_access_token(
-            user,
-            lambda access_token: get_owned_playlists(access_token, user.id)
-        )
-        playlist_map = {p["id"]: p["name"] for p in owned_playlists}
+    playlist_infos = [{"id": playlist_id, "name": playlist_map[playlist_id]} for playlist_id in playlist_ids]
 
-        # Build playlist info list
-        playlist_infos = []
-        for pid in playlist_ids:
-            name = playlist_map.get(pid, "Unknown Playlist")
-            playlist_infos.append({"id": pid, "name": name})
-
-        # Scan playlists
-        result = with_user_access_token(
-            user,
-            lambda access_token: scan_playlists_parallel(access_token, playlist_infos, country_code)
-        )
-        return Response(result, status=status.HTTP_200_OK)
-    except SpotifyReauthorizationRequiredException:
-        raise
-    except Exception as e:
-        return Response(
-            {"error": str(e)},
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR
-        )
+    result = with_user_access_token(
+        user,
+        lambda access_token: scan_playlists_parallel(access_token, playlist_infos, country_code)
+    )
+    return Response(result, status=status.HTTP_200_OK)
 
 
 @api_view(['POST'])
-@authentication_classes([])
-@permission_classes([])
+@authentication_classes([TrackWatchSessionAuthentication])
+@permission_classes([IsAuthenticated])
 def remove_ghost_tracks(request):
-    user, error_response = get_token_and_user(request)
-    if error_response:
-        return error_response
+    user = request.user
 
-    # Parse request body
-    removals = request.data.get("removals", [])
+    removals = _validate_removals(request.data.get("removals"))
 
-    # Validate removals
-    if not removals or not isinstance(removals, list):
-        return Response(
-            {"error": "removals is required and must be a non-empty array"},
-            status=status.HTTP_400_BAD_REQUEST
-        )
+    playlist_map = _owned_playlist_map(user)
+    _require_owned_playlists([removal["playlistId"] for removal in removals], playlist_map)
 
     for removal in removals:
-        if not removal.get("playlistId") or not removal.get("trackUris"):
-            return Response(
-                {"error": "Each removal must have playlistId and trackUris"},
-                status=status.HTTP_400_BAD_REQUEST
-            )
+        removal["playlistName"] = playlist_map[removal["playlistId"]]
 
-    try:
-        # Get playlist names for the response
-        owned_playlists = with_user_access_token(
-            user,
-            lambda access_token: get_owned_playlists(access_token, user.id)
-        )
-        playlist_map = {p["id"]: p["name"] for p in owned_playlists}
+    results = with_user_access_token(
+        user,
+        lambda access_token: remove_tracks_from_playlists(access_token, removals)
+    )
 
-        # Add playlist names to removals
-        for removal in removals:
-            removal["playlistName"] = playlist_map.get(removal["playlistId"], "Unknown Playlist")
+    total_removed = sum(r["removedCount"] for r in results)
+    total_failed = sum(r["failedCount"] for r in results)
 
-        results = with_user_access_token(
-            user,
-            lambda access_token: remove_tracks_from_playlists(access_token, removals)
-        )
-
-        total_removed = sum(r["removedCount"] for r in results)
-        total_failed = sum(r["failedCount"] for r in results)
-
-        return Response({
-            "results": results,
-            "totalRemoved": total_removed,
-            "totalFailed": total_failed
-        }, status=status.HTTP_200_OK)
-    except SpotifyReauthorizationRequiredException:
-        raise
-    except Exception as e:
-        return Response(
-            {"error": str(e)},
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR
-        )
+    return Response({
+        "results": results,
+        "totalRemoved": total_removed,
+        "totalFailed": total_failed
+    }, status=status.HTTP_200_OK)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,7 @@ APScheduler==3.11.0
 asgiref==3.8.1
 certifi==2025.4.26
 charset-normalizer==3.4.2
-Django==5.2.14
+Django==5.2.16
 django-apscheduler==0.7.0
 django-cors-headers==4.7.0
 djangorestframework==3.16.0

--- a/backend/trackwatch/settings.py
+++ b/backend/trackwatch/settings.py
@@ -5,9 +5,13 @@ from urllib.parse import unquote, urlparse
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+
+def _csv_config(name, default):
+  return [value.strip() for value in config(name, default=default).split(",") if value.strip()]
+
 SECRET_KEY = config("SECRET_KEY")
 DEBUG = config("DEBUG", default=False, cast=bool)
-ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="*").split(",")
+ALLOWED_HOSTS = _csv_config("ALLOWED_HOSTS", "localhost,127.0.0.1,backend")
 
 INSTALLED_APPS = [
   "django.contrib.admin",
@@ -95,20 +99,20 @@ TEMPLATES = [
   },
 ]
 
-CORS_ALLOWED_ORIGINS = [
-  "http://localhost:5173",
-  "http://127.0.0.1:5173",
-  "https://trackwatch.emlopezr.com",
-]
+CORS_ALLOWED_ORIGINS = _csv_config(
+  "CORS_ALLOWED_ORIGINS",
+  "http://localhost:5173,http://127.0.0.1:5173,https://trackwatch.emlopezr.com",
+)
 
 CORS_ALLOW_HEADERS = ['accept', 'accept-encoding', 'authorization', 'content-type', 'dnt', 'origin', 'user-agent', 'x-csrftoken', 'x-requested-with', 'x-admin-key']
 CORS_ALLOW_CREDENTIALS = True
 
-CSRF_TRUSTED_ORIGINS = [
-  "http://localhost:5173",
-  "http://127.0.0.1:5173",
-  "https://trackwatch.emlopezr.com",
-]
+CSRF_TRUSTED_ORIGINS = _csv_config(
+  "CSRF_TRUSTED_ORIGINS",
+  "http://localhost:5173,http://127.0.0.1:5173,https://trackwatch.emlopezr.com",
+)
+
+FRONTEND_BASE_URL = config("FRONTEND_BASE_URL", default="https://trackwatch.emlopezr.com").rstrip("/")
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 SESSION_COOKIE_HTTPONLY = True
@@ -116,6 +120,13 @@ SESSION_COOKIE_SAMESITE = "Lax"
 SESSION_COOKIE_SECURE = not DEBUG
 CSRF_COOKIE_SAMESITE = "Lax"
 CSRF_COOKIE_SECURE = not DEBUG
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_REFERRER_POLICY = "same-origin"
+X_FRAME_OPTIONS = "DENY"
+SECURE_SSL_REDIRECT = config("SECURE_SSL_REDIRECT", default=False, cast=bool)
+SECURE_HSTS_SECONDS = config("SECURE_HSTS_SECONDS", default=0, cast=int)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = config("SECURE_HSTS_INCLUDE_SUBDOMAINS", default=False, cast=bool)
+SECURE_HSTS_PRELOAD = config("SECURE_HSTS_PRELOAD", default=False, cast=bool)
 
 WSGI_APPLICATION = "trackwatch.wsgi.application"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,9 +30,15 @@ services:
         environment: &backend-env
             # Django settings
             SECRET_KEY: ${SECRET_KEY:?Django secret key required}
-            ADMIN_KEY: ${ADMIN_KEY:-}
+            ADMIN_KEY: ${ADMIN_KEY:?Admin webhook key required}
             DEBUG: ${DEBUG:-False}
-            ALLOWED_HOSTS: ${ALLOWED_HOSTS:-*}
+            ALLOWED_HOSTS: ${ALLOWED_HOSTS:-localhost,127.0.0.1,backend}
+            CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:5173,http://127.0.0.1:5173,https://trackwatch.emlopezr.com}
+            CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-http://localhost:5173,http://127.0.0.1:5173,https://trackwatch.emlopezr.com}
+            SECURE_SSL_REDIRECT: ${SECURE_SSL_REDIRECT:-False}
+            SECURE_HSTS_SECONDS: ${SECURE_HSTS_SECONDS:-0}
+            SECURE_HSTS_INCLUDE_SUBDOMAINS: ${SECURE_HSTS_INCLUDE_SUBDOMAINS:-False}
+            SECURE_HSTS_PRELOAD: ${SECURE_HSTS_PRELOAD:-False}
 
             # Database
             DATABASE_NAME: ${DATABASE_NAME:-trackwatch}

--- a/entrypoint-aio.sh
+++ b/entrypoint-aio.sh
@@ -7,7 +7,7 @@ echo "=== TrackWatch All-in-One Container Starting ==="
 PG_DATA="/var/lib/postgresql/data"
 DB_NAME="${DATABASE_NAME:-trackwatch}"
 DB_USER="${DATABASE_USER:-trackwatch}"
-DB_PASS="${DATABASE_PASSWORD:-trackwatch}"
+DB_PASS="${DATABASE_PASSWORD:?Database password required}"
 PG_BINDIR="${PG_BINDIR:-$(pg_config --bindir)}"
 
 if [ -z "$PG_BINDIR" ] || [ ! -x "$PG_BINDIR/postgres" ]; then
@@ -21,18 +21,47 @@ echo "Using PostgreSQL binaries from: $PG_BINDIR"
 if [ ! -f "$PG_DATA/PG_VERSION" ]; then
     echo "Initializing PostgreSQL database..."
     chown -R postgres:postgres "$PG_DATA"
-    su - postgres -c "'$PG_BINDIR'/initdb -D '$PG_DATA'"
+    runuser -u postgres -- "$PG_BINDIR/initdb" -D "$PG_DATA" --auth-local=peer --auth-host=scram-sha-256
 
     # Start PostgreSQL temporarily to create user and database
-    su - postgres -c "'$PG_BINDIR'/pg_ctl -D '$PG_DATA' -w start -o '-c listen_addresses=127.0.0.1'"
+    runuser -u postgres -- "$PG_BINDIR/pg_ctl" -D "$PG_DATA" -w start -o "-c listen_addresses=127.0.0.1"
 
-    # Create user and database
-    su - postgres -c "psql -c \"CREATE USER $DB_USER WITH PASSWORD '$DB_PASS';\""  2>/dev/null || true
-    su - postgres -c "psql -c \"CREATE DATABASE $DB_NAME OWNER $DB_USER;\""  2>/dev/null || true
-    su - postgres -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER;\""
+    # Create the role and database without interpolating credentials into shell or SQL.
+    runuser -u postgres -- env DB_NAME="$DB_NAME" DB_USER="$DB_USER" DB_PASS="$DB_PASS" python - <<'PY'
+import os
+
+import psycopg2
+from psycopg2 import sql
+
+database_name = os.environ["DB_NAME"]
+database_user = os.environ["DB_USER"]
+database_password = os.environ["DB_PASS"]
+
+connection = psycopg2.connect(dbname="postgres")
+try:
+    connection.autocommit = True
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", [database_user])
+        if cursor.fetchone() is None:
+            cursor.execute(
+                sql.SQL("CREATE ROLE {} LOGIN PASSWORD %s").format(sql.Identifier(database_user)),
+                [database_password],
+            )
+
+        cursor.execute("SELECT 1 FROM pg_database WHERE datname = %s", [database_name])
+        if cursor.fetchone() is None:
+            cursor.execute(
+                sql.SQL("CREATE DATABASE {} OWNER {}").format(
+                    sql.Identifier(database_name),
+                    sql.Identifier(database_user),
+                )
+            )
+finally:
+    connection.close()
+PY
 
     # Stop temporary PostgreSQL (supervisord will start it properly)
-    su - postgres -c "'$PG_BINDIR'/pg_ctl -D '$PG_DATA' -w stop"
+    runuser -u postgres -- "$PG_BINDIR/pg_ctl" -D "$PG_DATA" -w stop
     echo "PostgreSQL initialized successfully!"
 else
     echo "PostgreSQL data directory found, skipping initialization."
@@ -74,11 +103,11 @@ echo "PostgreSQL is ready!"
 
 # Run migrations
 echo "Running database migrations..."
-python manage.py migrate --noinput
+runuser -u trackwatch --preserve-environment -- python manage.py migrate --noinput
 
 # Collect static files
 echo "Collecting static files..."
-python manage.py collectstatic --noinput
+runuser -u trackwatch --preserve-environment -- python manage.py collectstatic --noinput
 
 # Generate runtime env.js for frontend (allows pre-built images to use env vars)
 echo "Generating frontend runtime configuration..."
@@ -90,6 +119,9 @@ window.__ENV__ = {
 ENVEOF
 
 echo "=== TrackWatch is running! ==="
+
+# Start application processes only after the database schema and runtime config are ready.
+supervisorctl -c /etc/supervisord.conf start nginx gunicorn scheduler
 
 # Wait for supervisord (it's already our main process)
 wait $SUPERVISORD_PID

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,16 +1,16 @@
 # Build the React application
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml* package-lock.json* ./
+COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml package-lock.json* ./
 
-RUN corepack enable && corepack prepare pnpm@10.6.3 --activate
-RUN pnpm install --frozen-lockfile || npm ci
+RUN corepack enable && corepack prepare pnpm@11.11.0 --activate
+RUN pnpm install --frozen-lockfile
 
 COPY . .
 
-RUN pnpm run build || npm run build
+RUN pnpm run build
 
 FROM nginx:alpine
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -15,9 +15,11 @@ server {
     gzip_types text/plain text/css text/xml text/javascript application/javascript application/json application/xml;
 
     # Security headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: https:; object-src 'none'; script-src 'self'; style-src 'self'" always;
+    add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
 
     location /api/ {
         # Strip /api prefix and proxy to backend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "packageManager": "pnpm@10.6.3",
+  "packageManager": "pnpm@11.11.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
@@ -29,26 +29,5 @@
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.15.0",
     "vite": "^6.4.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "@babel/core": "7.29.6",
-      "js-yaml": "4.2.0",
-      "on-headers": ">=1.1.0",
-      "@eslint/plugin-kit": ">=0.3.4",
-      "minimatch@3": "^3.1.3",
-      "minimatch@9": ">=9.0.6",
-      "minimatch@3>brace-expansion": "1.1.13",
-      "ajv@6": "^6.14.0",
-      "ajv@8": "^8.18.0",
-      "rollup": ">=4.59.0",
-      "flatted": ">=3.4.2",
-      "picomatch@2": "^2.3.2",
-      "picomatch@4": "^4.0.4",
-      "fast-uri": ">=3.1.2",
-      "brace-expansion": ">=5.0.5",
-      "postcss": ">=8.5.10",
-      "esbuild": ">=0.28.1"
-    }
   }
 }

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,21 @@
+allowBuilds:
+  esbuild: true
+
+overrides:
+  '@babel/core': 7.29.6
+  js-yaml: 4.2.0
+  on-headers: '>=1.1.0'
+  '@eslint/plugin-kit': '>=0.3.4'
+  minimatch@3: ^3.1.3
+  minimatch@9: '>=9.0.6'
+  minimatch@3>brace-expansion: 1.1.13
+  ajv@6: ^6.14.0
+  ajv@8: ^8.18.0
+  rollup: '>=4.59.0'
+  flatted: '>=3.4.2'
+  picomatch@2: ^2.3.2
+  picomatch@4: ^4.0.4
+  fast-uri: '>=3.1.2'
+  brace-expansion: '>=5.0.5'
+  postcss: '>=8.5.10'
+  esbuild: '>=0.28.1'

--- a/nginx-aio.conf
+++ b/nginx-aio.conf
@@ -14,9 +14,11 @@ server {
     gzip_types text/plain text/css text/xml text/javascript application/javascript application/json application/xml;
 
     # Security headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: https:; object-src 'none'; script-src 'self'; style-src 'self'" always;
+    add_header Permissions-Policy "camera=(), geolocation=(), microphone=()" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
 
     location /api/ {
         # Strip /api prefix and proxy to backend
@@ -30,10 +32,6 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-
-        # Pass through custom Spotify authentication headers
-        proxy_set_header X-Spotify-Access-Token $http_x_spotify_access_token;
-        proxy_set_header X-Spotify-Refresh-Token $http_x_spotify_refresh_token;
 
         # Timeouts for long-running operations
         proxy_connect_timeout 60s;

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -15,7 +15,7 @@ serverurl=unix:///var/run/supervisor.sock
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:postgresql]
-command=/bin/bash -lc 'exec "${PG_BINDIR:-$(pg_config --bindir)}/postgres" -D /var/lib/postgresql/data -c listen_addresses=127.0.0.1 -c port=5432'
+command=%(ENV_PG_BINDIR)s/postgres -D /var/lib/postgresql/data -c listen_addresses=127.0.0.1 -c port=5432
 user=postgres
 priority=1
 autostart=true
@@ -31,7 +31,7 @@ stderr_logfile_maxbytes=0
 [program:nginx]
 command=nginx -g "daemon off;"
 priority=10
-autostart=true
+autostart=false
 autorestart=true
 startsecs=5
 startretries=3
@@ -44,8 +44,9 @@ stderr_logfile_maxbytes=0
 [program:gunicorn]
 command=gunicorn trackwatch.wsgi:application --bind 127.0.0.1:8000 --workers %(ENV_GUNICORN_WORKERS)s --threads %(ENV_GUNICORN_THREADS)s --timeout %(ENV_GUNICORN_TIMEOUT)s --access-logfile - --error-logfile - --capture-output --enable-stdio-inheritance
 directory=/app
+user=trackwatch
 priority=20
-autostart=true
+autostart=false
 autorestart=true
 startsecs=10
 startretries=3
@@ -60,8 +61,9 @@ stderr_logfile_maxbytes=0
 [program:scheduler]
 command=python manage.py run_scheduler
 directory=/app
+user=trackwatch
 priority=30
-autostart=true
+autostart=false
 autorestart=true
 startsecs=10
 startretries=3


### PR DESCRIPTION
## Summary

- upgrade Django from 5.2.14 to 5.2.16, resolving the eight advisories reported by `pip-audit`
- enforce CSRF-aware TrackWatch session authentication on Ghost Tracks mutations, validate Spotify IDs/URIs, cap request sizes, and require playlist ownership
- harden OAuth state/redirect handling, admin webhook authentication, Django host/cookie/header settings, and sensitive Django Admin fields
- remove credential interpolation and trust authentication from the All-in-One PostgreSQL bootstrap; run Gunicorn and the scheduler as an unprivileged user
- make frontend installs reproducible with pnpm 11, an explicit build-script allowlist, Node 22 builders, and stronger Nginx security headers

## Root causes

Several endpoints mixed custom session authentication with DRF authentication disabled, which also disabled DRF's CSRF enforcement. Deployment defaults were permissive, and the All-in-One bootstrap interpolated environment-controlled database values through shell and SQL strings while application processes ran as root. The active Django pin also lagged current security releases.

## Validation

- `python manage.py test app.tests`: 34 tests passed
- `python manage.py check --deploy`: no issues with production security settings
- `bandit -r app trackwatch -x app/tests -ll -q`: no medium/high findings
- `pip-audit -r backend/requirements.txt`: no known vulnerabilities
- `pnpm audit --audit-level low`: no known vulnerabilities
- `pnpm run lint`
- `pnpm run build`
- `docker compose config -q`
- All-in-One Docker image built and reached `healthy`; Gunicorn and scheduler ran as `trackwatch`

## Dependabot note

GitHub currently reports 13 open alerts on the default branch. This PR fixes the one alert tied to the active `backend/requirements.txt`. The other 12 reference a deleted root-level `requirements.txt` and are stale repository alerts; the current backend and frontend manifests both audit clean.