### PR TITLE
Fix July frontend security advisories

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.15.0",
     "serve": "^14.2.4"
   },
   "devDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -6,21 +6,21 @@ settings:
 
 overrides:
   '@babel/core': 7.29.6
-  js-yaml: 4.2.0
+  js-yaml: 4.3.0
   on-headers: '>=1.1.0'
   '@eslint/plugin-kit': '>=0.3.4'
   minimatch@3: ^3.1.3
   minimatch@9: '>=9.0.6'
-  minimatch@3>brace-expansion: 1.1.13
+  minimatch@3>brace-expansion: 1.1.16
   ajv@6: ^6.14.0
   ajv@8: ^8.18.0
   rollup: '>=4.59.0'
   flatted: '>=3.4.2'
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
-  fast-uri: '>=3.1.2'
-  brace-expansion: '>=5.0.5'
-  postcss: '>=8.5.10'
+  fast-uri: '>=3.1.4'
+  brace-expansion: '>=5.0.7'
+  postcss: '>=8.5.18'
   esbuild: '>=0.28.1'
 
 importers:
@@ -33,9 +33,6 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      react-router-dom:
-        specifier: ^7.15.0
-        version: 7.17.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       serve:
         specifier: ^14.2.4
         version: 14.2.4
@@ -467,66 +464,79 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -705,11 +715,11 @@ packages:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -780,10 +790,6 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  cookie@1.0.2:
-    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
-    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -911,8 +917,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@4.1.1:
+    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1039,8 +1045,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -1137,8 +1143,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1205,8 +1211,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.22:
+    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1236,23 +1242,6 @@ packages:
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
-
-  react-router-dom@7.17.0:
-    resolution: {integrity: sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.17.0:
-    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -1310,9 +1299,6 @@ packages:
     resolution: {integrity: sha512-qy1S34PJ/fcY8gjVGszDB3EXiPSk5FKhUa7tQe0UPRddxRidc2V6cNHPNewbE1D7MAkgLuWEt3Vw56vYy73tzQ==}
     engines: {node: '>= 14'}
     hasBin: true
-
-  set-cookie-parser@2.7.1:
-    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1713,7 +1699,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2009,7 +1995,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 4.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2048,12 +2034,12 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2122,8 +2108,6 @@ snapshots:
   content-disposition@0.5.2: {}
 
   convert-source-map@2.0.0: {}
-
-  cookie@1.0.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2287,7 +2271,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@4.1.1: {}
 
   fastq@1.19.1:
     dependencies:
@@ -2377,7 +2361,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -2443,11 +2427,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.16
 
   minimist@1.2.8: {}
 
@@ -2455,7 +2439,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -2508,9 +2492,9 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.16:
+  postcss@8.5.22:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2536,20 +2520,6 @@ snapshots:
       scheduler: 0.23.2
 
   react-refresh@0.14.2: {}
-
-  react-router-dom@7.17.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-router: 7.17.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-
-  react-router@7.17.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      cookie: 1.0.2
-      react: 18.3.1
-      set-cookie-parser: 2.7.1
-    optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:
@@ -2642,8 +2612,6 @@ snapshots:
       update-check: 1.5.4
     transitivePeerDependencies:
       - supports-color
-
-  set-cookie-parser@2.7.1: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -2738,7 +2706,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.16
+      postcss: 8.5.22
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -3,19 +3,19 @@ allowBuilds:
 
 overrides:
   '@babel/core': 7.29.6
-  js-yaml: 4.2.0
+  js-yaml: 4.3.0
   on-headers: '>=1.1.0'
   '@eslint/plugin-kit': '>=0.3.4'
   minimatch@3: ^3.1.3
   minimatch@9: '>=9.0.6'
-  minimatch@3>brace-expansion: 1.1.13
+  minimatch@3>brace-expansion: 1.1.16
   ajv@6: ^6.14.0
   ajv@8: ^8.18.0
   rollup: '>=4.59.0'
   flatted: '>=3.4.2'
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
-  fast-uri: '>=3.1.2'
-  brace-expansion: '>=5.0.5'
-  postcss: '>=8.5.10'
+  fast-uri: '>=3.1.4'
+  brace-expansion: '>=5.0.7'
+  postcss: '>=8.5.18'
   esbuild: '>=0.28.1'

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import UserProvider from './context/UserProvider';
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import { RouterProvider } from './routing/Router';
+import { useLocation } from './routing/useRouter';
 import MainRoute from './routes/MainRoute/MainRoute';
 import CallbackRoute from './routes/CallbackRoute/CallbackRoute';
 import EulaPage from './pages/EulaPage/EulaPage';
@@ -7,19 +8,36 @@ import PrivacyPage from './pages/PrivacyPage/PrivacyPage';
 import InstallPage from './pages/InstallPage/InstallPage';
 import LoginPage from './pages/LoginPage/LoginPage';
 
+const AppRoutes = () => {
+  const location = useLocation();
+  const pathname = location.pathname === '/'
+    ? '/'
+    : location.pathname.replace(/\/+$/, '');
+
+  switch (pathname) {
+    case '/':
+      return <MainRoute />;
+    case '/callback':
+      return <CallbackRoute />;
+    case '/eula':
+      return <EulaPage />;
+    case '/privacy':
+      return <PrivacyPage />;
+    case '/install':
+      return <InstallPage />;
+    case '/login':
+      return <LoginPage />;
+    default:
+      return null;
+  }
+};
+
 const App = () => {
   return (
     <UserProvider>
-      <Router>
-        <Routes>
-          <Route path="/" element={<MainRoute />} />
-          <Route path="/callback" element={<CallbackRoute />} />
-          <Route path="/eula" element={<EulaPage />} />
-          <Route path="/privacy" element={<PrivacyPage />} />
-          <Route path="/install" element={<InstallPage />} />
-          <Route path="/login" element={<LoginPage />} />
-        </Routes>
-      </Router>
+      <RouterProvider>
+        <AppRoutes />
+      </RouterProvider>
     </UserProvider>
   );
 };

--- a/frontend/src/pages/InstallPage/InstallPage.tsx
+++ b/frontend/src/pages/InstallPage/InstallPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from '../../routing/Router';
 import trackWatchlogo from '../../assets/svg/logo.svg';
 import './InstallPage.css';
 

--- a/frontend/src/pages/LandingPage/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from '../../routing/Router';
 import { getSpotifyAuthUrl } from '../../services/spotify/spotifyAuth';
 import { HIDE_PUBLIC_LOGIN } from '../../common/constants';
 import FeatureCard from '../../layout/FeatureCard/FeatureCard';

--- a/frontend/src/routes/CallbackRoute/CallbackRoute.tsx
+++ b/frontend/src/routes/CallbackRoute/CallbackRoute.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from '../../routing/useRouter';
 import { exchangeSpotifyCode } from '../../services/trackwatch/trackwatchUsers';
 import { useUser } from '../../context/useUser';
 import Spinner from '../../components/Spinner/Spinner';

--- a/frontend/src/routing/Router.tsx
+++ b/frontend/src/routing/Router.tsx
@@ -1,0 +1,113 @@
+import {
+  type AnchorHTMLAttributes,
+  type MouseEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { RouterContext, type NavigateOptions, type RouterLocation } from './RouterContext';
+import { useNavigate } from './useRouter';
+
+interface RouterProviderProps {
+  children: ReactNode;
+}
+
+interface LinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+  to: string;
+}
+
+const getLocation = (): RouterLocation => ({
+  pathname: window.location.pathname,
+  search: window.location.search,
+  hash: window.location.hash,
+});
+
+export const RouterProvider = ({ children }: RouterProviderProps) => {
+  const [location, setLocation] = useState(getLocation);
+
+  useEffect(() => {
+    const handlePopState = () => setLocation(getLocation());
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  const navigate = useCallback((to: string, options: NavigateOptions = {}) => {
+    const destination = new URL(to, window.location.href);
+
+    if (destination.origin !== window.location.origin) {
+      window.location.assign(destination.href);
+      return;
+    }
+
+    const destinationPath = `${destination.pathname}${destination.search}${destination.hash}`;
+    const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+    if (destinationPath === currentPath) {
+      return;
+    }
+
+    if (options.replace) {
+      window.history.replaceState(null, '', destinationPath);
+    } else {
+      window.history.pushState(null, '', destinationPath);
+    }
+
+    setLocation(getLocation());
+    window.scrollTo({ top: 0, left: 0 });
+  }, []);
+
+  const value = useMemo(() => ({ location, navigate }), [location, navigate]);
+
+  return (
+    <RouterContext.Provider value={value}>
+      {children}
+    </RouterContext.Provider>
+  );
+};
+
+export const Link = ({
+  to,
+  onClick,
+  target,
+  children,
+  ...anchorProps
+}: LinkProps) => {
+  const navigate = useNavigate();
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event);
+
+    if (
+      event.defaultPrevented
+      || event.button !== 0
+      || event.metaKey
+      || event.ctrlKey
+      || event.shiftKey
+      || event.altKey
+      || (target && target !== '_self')
+    ) {
+      return;
+    }
+
+    const destination = new URL(to, window.location.href);
+    if (destination.origin !== window.location.origin) {
+      return;
+    }
+
+    event.preventDefault();
+    navigate(`${destination.pathname}${destination.search}${destination.hash}`);
+  };
+
+  return (
+    <a
+      {...anchorProps}
+      href={to}
+      target={target}
+      onClick={handleClick}
+    >
+      {children}
+    </a>
+  );
+};

--- a/frontend/src/routing/RouterContext.ts
+++ b/frontend/src/routing/RouterContext.ts
@@ -1,0 +1,18 @@
+import { createContext } from 'react';
+
+export interface RouterLocation {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+export interface NavigateOptions {
+  replace?: boolean;
+}
+
+export interface RouterContextValue {
+  location: RouterLocation;
+  navigate: (to: string, options?: NavigateOptions) => void;
+}
+
+export const RouterContext = createContext<RouterContextValue | null>(null);

--- a/frontend/src/routing/useRouter.ts
+++ b/frontend/src/routing/useRouter.ts
@@ -1,0 +1,16 @@
+import { useContext } from 'react';
+import { RouterContext } from './RouterContext';
+
+const useRouter = () => {
+  const context = useContext(RouterContext);
+
+  if (!context) {
+    throw new Error('Router hooks must be used within RouterProvider');
+  }
+
+  return context;
+};
+
+export const useLocation = () => useRouter().location;
+
+export const useNavigate = () => useRouter().navigate;


### PR DESCRIPTION
## Summary

- update vulnerable transitive packages (`brace-expansion`, `js-yaml`, `fast-uri`, and `postcss`) to patched versions
- remove `react-router-dom`, whose newly published RSC advisory has no stable patched release, and replace the six simple SPA routes with a small same-origin internal router
- regenerate the pnpm lockfile so the resolved dependency graph contains no known npm advisories

## Root cause

The lockfile still resolved versions affected by newly published denial-of-service, host-confusion, YAML parsing, and source-map disclosure advisories. React Router also received multiple advisories on July 24; the latest RSC-mode advisory declares a patched version that is not yet available on npm. TrackWatch only uses basic browser routing, so retaining the package would leave a known vulnerable dependency even though the vulnerable RSC mode is not used.

## Impact

The frontend keeps the existing routes and SPA navigation behavior while eliminating the vulnerable dependency tree. Backend behavior and APIs are unchanged.

## Validation

- `pnpm audit --audit-level low --json`: 0 vulnerabilities
- `uvx pip-audit -r requirements.txt`: 0 vulnerabilities
- `npm run lint`: passed without warnings
- `npm run build`: passed
- Playwright smoke test: internal navigation, browser history, `/install`, `/eula`, `/privacy`, `/login`, and invalid OAuth callback redirect passed
- Django tests: 34 passed
- `uvx bandit -q -r app trackwatch -ll`: passed
- `python manage.py check --deploy`: no issues
- frontend Docker image build: passed
