### PR TITLE
fix: update frontend security overrides

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,16 +11,16 @@ overrides:
   '@eslint/plugin-kit': '>=0.3.4'
   minimatch@3: ^3.1.3
   minimatch@9: '>=9.0.6'
-  minimatch@3>brace-expansion: 1.1.16
+  minimatch@3>brace-expansion: 1.1.18
   ajv@6: ^6.14.0
   ajv@8: ^8.18.0
   rollup: '>=4.59.0'
   flatted: '>=3.4.2'
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
-  fast-uri: '>=3.1.4'
-  brace-expansion: '>=5.0.7'
-  postcss: '>=8.5.18'
+  fast-uri: '>=4.1.2'
+  brace-expansion: '>=5.0.9'
+  postcss: '>=8.5.23'
   esbuild: '>=0.28.1'
 
 importers:
@@ -715,12 +715,12 @@ packages:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -917,8 +917,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1211,8 +1211,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.22:
-    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1995,7 +1995,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2034,12 +2034,12 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2271,7 +2271,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fastq@1.19.1:
     dependencies:
@@ -2427,11 +2427,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 
@@ -2492,7 +2492,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.22:
+  postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -2706,7 +2706,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.22
+      postcss: 8.5.25
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -8,14 +8,14 @@ overrides:
   '@eslint/plugin-kit': '>=0.3.4'
   minimatch@3: ^3.1.3
   minimatch@9: '>=9.0.6'
-  minimatch@3>brace-expansion: 1.1.16
+  minimatch@3>brace-expansion: 1.1.18
   ajv@6: ^6.14.0
   ajv@8: ^8.18.0
   rollup: '>=4.59.0'
   flatted: '>=3.4.2'
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
-  fast-uri: '>=3.1.4'
-  brace-expansion: '>=5.0.7'
-  postcss: '>=8.5.18'
+  fast-uri: '>=4.1.2'
+  brace-expansion: '>=5.0.9'
+  postcss: '>=8.5.23'
   esbuild: '>=0.28.1'


### PR DESCRIPTION
## Summary

- update the transitive `fast-uri` resolution to `4.1.2`, fixing GHSA-7p8r-x3mc-p8w7 / CVE-2026-18446
- update `brace-expansion` to `1.1.18` and `5.0.9`
- update `postcss` to `8.5.25`, beyond the patched `8.5.23` floor
- regenerate the pnpm lockfile

These updates are included before the security release so the frontend does not ship with newly published npm advisories.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts` with `CI=true`
- `pnpm audit --audit-level low`: no known vulnerabilities
- `CI=true pnpm run lint`: passed
- `pnpm run build`: passed
- `git diff --check`: passed

This PR is based on `develop` and is intended to be included in release `2.1.2`.