### PR TITLE
fix: patch frontend dependency vulnerabilities

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -6,7 +6,8 @@ settings:
 
 overrides:
   '@babel/core': 7.29.6
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
+  postcss>nanoid: 3.3.18
   on-headers: '>=1.1.0'
   '@eslint/plugin-kit': '>=0.3.4'
   minimatch@3: ^3.1.3
@@ -1045,8 +1046,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -1143,8 +1144,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1699,7 +1700,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2361,7 +2362,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -2439,7 +2440,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -2494,7 +2495,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -3,7 +3,8 @@ allowBuilds:
 
 overrides:
   '@babel/core': 7.29.6
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
+  postcss>nanoid: 3.3.18
   on-headers: '>=1.1.0'
   '@eslint/plugin-kit': '>=0.3.4'
   minimatch@3: ^3.1.3


### PR DESCRIPTION
## Summary

- Bump the workspace override for `js-yaml` from `4.3.0` to `4.3.1`, resolving Dependabot alert #107 (GHSA-5p4m-2wfm-xmqj).
- Pin `postcss>nanoid` to `3.3.18`, resolving the high-severity `pnpm audit` finding GHSA-2v37-7h3g-55p8 that was present in the base branch.
- Regenerate `frontend/pnpm-lock.yaml` with pnpm.

## Validation

- `CI=true pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm audit` — 0 known vulnerabilities
- `pnpm run lint` — passed
- `CI=true pnpm run build` — passed
- `git diff --check` — passed

Performance impact: N/A (dependency-only change).

No backend files or runtime code were changed.